### PR TITLE
Escape POST body values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meh-activity-logger",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Log custom events and pageviews with opinionated defaults to Google Analytics through Express middleware, Node or the browser.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/actions/sendGaMeasurement.js
+++ b/src/actions/sendGaMeasurement.js
@@ -24,7 +24,9 @@ export default async (type, properties = {}) => {
   const body = new URLSearchParams();
 
   Object.keys(filteredProperties).forEach(
-    (key) => filteredProperties[key] != null && body.append(key, filteredProperties[key]),
+    (key) =>
+      filteredProperties[key] != null &&
+      body.append(key, encodeURIComponent(filteredProperties[key])),
   );
 
   const response = await fetch(googleAnalyticsEndpoint, { method: 'POST', body });


### PR DESCRIPTION
Escape body values to prevent GA from reading query parameters as measurement parameters:
```json
{
  "hitParsingResult": [
    {
      "valid": true,
      "parserMessage": [
        {
          "messageType": "INFO",
          "description": "Unrecognized parameter 'settings' found.",
          "messageCode": "UNKNOWN_PARAMETER",
          "parameter": "settings"
        }
      ],
      "hit": "/debug/collect?v=1&tid=UA-26548270-15&uip=xxxxxxxxx&ua=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36&dr=http://localhost:3000/&dh=localhost&dp=/api/transform/c33d02cb-df77-4b8b-a4cc-7fd11c3cf1ca?transformer-id=rich_media&settings=%7B%22static%22%3A%7B%22localizeCdn%22%3Afalse%7D%7D&t=event&uid=-975727311&ec=Primary KPI&ea=Transformed creative&el=rich_media&an=creative-transformer&aid=creative-transformer&cd1=creative-transformer&av=1.2.0&cd2=1.2.0&_anon_uip=127.0.0.0"
    }
  ],
  "parserMessage": [
    { "messageType": "INFO", "description": "Found 1 hit in the request." }
  ]
}
```